### PR TITLE
Added libmetis-dev to linux install dependencies

### DIFF
--- a/_sources/install.rst.txt
+++ b/_sources/install.rst.txt
@@ -86,7 +86,8 @@ Dependencies from the default Ubuntu repositories::
         libglew-dev \
         qtbase5-dev \
         libqt5opengl5-dev \
-        libcgal-dev
+        libcgal-dev \
+        libmetis-dev
 
 Under Ubuntu 16.04/18.04 the CMake configuration scripts of CGAL are broken and
 you must also install the CGAL Qt5 package::


### PR DESCRIPTION
Compilation from source code fails under ubuntu because of missing library, as specified in https://github.com/colmap/colmap/issues/1441 . The proposed solution of installing libmetis-dev solves this issue as mentioned here https://github.com/colmap/colmap/issues/1441#issuecomment-1054350018 