### PR TITLE
Provide permanent anchor for Windows source installation section

### DIFF
--- a/_sources/install.rst.txt
+++ b/_sources/install.rst.txt
@@ -186,6 +186,8 @@ Run COLMAP::
     colmap gui
 
 
+.. _windows-source:
+
 Windows
 -------
 


### PR DESCRIPTION
The second Windows section in the install doc, dedicated to installation from source, was getting renamed because the section name "windows" was already taken.

The exact result was not specified and changed between renders of the page, leading to a dead link in the PyCOLMAP install docs.